### PR TITLE
throttle number of tests running concurrently to concurrentLimit

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,16 @@
 const debounce = require('debounce')
 const { api } = require('./lib/api')
 const { createReport } = require('./lib/pipeline')
+const semaphoreFactory = require('semaphore')
 
-module.exports = tape => {
+module.exports = (tape, concurrentLimit = 0) => {
   process.stdout = process.stdout || require('browser-stdout')()
   const registerTest = debounce(
     () => Promise.all(state.testsEnded).then(() => report.end()), 100
   )
   let state = {
+    semaphore: (concurrentLimit > 0) ? semaphoreFactory(concurrentLimit) : null,
+    concurrentLimit: concurrentLimit, // 0 => infinity, no limit
     only: false,
     pipedToProcess: false,
     testsEnded: [],

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,17 +4,21 @@ const { createTestStream } = require('./pipeline')
 module.exports = {
   api: (state, tape, report) => {
     const testConcurrent = (...args) => {
-      state.registerTest()
-      process.nextTick(() => {
-        if (!state.only) {
-          const harness = tape.createHarness()
-          const { testReport, testEnded } = createTestStream(harness)
-          state.testsEnded.push(testEnded)
-          report.setMaxListeners(report.getMaxListeners() + 1)
-          testReport.pipe(report)
-          harness(...args)
-        }
-      })
+      const func = () => {
+        state.registerTest()
+        process.nextTick(() => {
+          if (!state.only) {
+            const harness = tape.createHarness()
+            const { testReport, testEnded } = createTestStream(harness)
+            state.testsEnded.push(testEnded)
+            report.setMaxListeners(report.getMaxListeners() + 1)
+            testReport.pipe(report)
+            harness(...args)
+          }
+        })
+        if (state.semaphore) { state.semaphore.leave() }
+      }
+      if (!state.semaphore) { func() } else { state.semaphore.take(func) }
     }
     testConcurrent.onFinish = fn => {
       state.runOnFinish.push(fn)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   ],
   "dependencies": {
     "browser-stdout": "^1.3.1",
-    "debounce": "^1.2.0"
+    "debounce": "^1.2.0",
+    "semaphore": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",


### PR DESCRIPTION
Throttle the number of concurrently running processes to a user settable parameter.
This is done using the "semaphore" package `take` and `leave` calls.