### PR TITLE
throttle number of tests running concurrently to concurrentLimit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.vscode
+

--- a/index.js
+++ b/index.js
@@ -1,19 +1,46 @@
-const debounce = require('debounce')
 const { api } = require('./lib/api')
 const { createReport } = require('./lib/pipeline')
+const semaphoreFactory = require('semaphore')
 
-module.exports = tape => {
+module.exports = (tape, concurrentLimit = 0) => {
   process.stdout = process.stdout || require('browser-stdout')()
-  const registerTest = debounce(
-    () => Promise.all(state.testsEnded).then(() => report.end()), 100
-  )
+  const registerTest = () => {
+    state.numTotal++
+    state.numPending++
+  }
+  const deregisterTest = () => {
+    if (state.semaphore) state.semaphore.leave()
+    // give any waiting task a chance to start by calling setTimeout(*,0)
+    setTimeout(() => {
+      state.numPending--
+      state.numRunning--
+      if (state.numPending === 0) {
+        Promise.all(state.testsEnded)
+          .then(() => {
+            if (state.numPending === 0 && !state.reportEndAlreadyCalled) {
+              state.reportEndAlreadyCalled = true
+              report.end()
+            }
+          })
+      }
+    }, 0)
+  }
+  const incrementRunning = () => { state.numRunning++ }
   let state = {
+    reportEndAlreadyCalled: false,
+    numRunning: 0, // diagnostic use only
+    numTotal: 0, // diagnostic use only
+    numPending: 0,
+    semaphore: (concurrentLimit > 0) ? semaphoreFactory(concurrentLimit) : null,
+    concurrentLimit: concurrentLimit, // 0 => infinity, no limit
     only: false,
     pipedToProcess: false,
     testsEnded: [],
     runOnFailure: [],
     runOnFinish: [],
-    registerTest
+    registerTest,
+    deregisterTest,
+    incrementRunning // diagnostic use only
   }
   const report = createReport(state)
   tape.createStream() // filter out all tape output

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,17 +4,24 @@ const { createTestStream } = require('./pipeline')
 module.exports = {
   api: (state, tape, report) => {
     const testConcurrent = (...args) => {
-      state.registerTest()
-      process.nextTick(() => {
-        if (!state.only) {
-          const harness = tape.createHarness()
-          const { testReport, testEnded } = createTestStream(harness)
-          state.testsEnded.push(testEnded)
-          report.setMaxListeners(report.getMaxListeners() + 1)
-          testReport.pipe(report)
-          harness(...args)
-        }
-      })
+      const func = () => {
+        process.nextTick(() => {
+          if (!state.only) {
+            state.registerTest()
+            const harness = tape.createHarness()
+            const { testReport, testEnded } = createTestStream(harness)
+            state.testsEnded.push(testEnded.then((r) => {
+              state.deregisterTest()
+              return r
+            }))
+            report.setMaxListeners(report.getMaxListeners() + 1)
+            testReport.pipe(report)
+            state.incrementRunning()
+            harness(...args)
+          }
+        })
+      }
+      if (!state.semaphore) { func() } else { state.semaphore.take(func) }
     }
     testConcurrent.onFinish = fn => {
       state.runOnFinish.push(fn)
@@ -23,20 +30,27 @@ module.exports = {
       state.runOnFailure.push(fn)
     }
     testConcurrent.only = (...args) => {
-      state.registerTest()
       state.only = true
+      state.registerTest()
       const harness = tape.createHarness()
       const { testReport, testEnded } = createTestStream(harness)
-      state.testsEnded.push(testEnded)
+      state.testsEnded.push(testEnded.then((r) => {
+        state.deregisterTest()
+        return r
+      }))
       testReport.pipe(report)
+      state.incrementRunning()
       harness(...args)
     }
     testConcurrent.skip = tape.skip
     testConcurrent.createStream = () => {
+      state.registerTest()
       state.pipedToProcess = false
       report.unpipe(process.stdout)
       const stream = PassThrough()
       report.pipe(stream)
+      state.incrementRunning()
+      state.deregisterTest()
       return stream
     }
     return testConcurrent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixed-tape",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.js",
   "scripts": {
     "test": "standard && tape test/*.spec.js | tap-spec",
@@ -31,7 +31,8 @@
   ],
   "dependencies": {
     "browser-stdout": "^1.3.1",
-    "debounce": "^1.2.0"
+    "debounce": "^1.2.0",
+    "semaphore": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/test/concurrent.spec.js
+++ b/test/concurrent.spec.js
@@ -1,0 +1,84 @@
+const test = require('tape')
+const proxyquire = require('proxyquire')
+const mixtape = require('../')
+
+process && process.setMaxListeners && process.setMaxListeners(Infinity)
+
+test('can run 20 waited test cases with concurrent limit==4', async t => {
+  t.plan(2)
+  try {
+    const tapeInstance = proxyquire('tape', {})
+    const testInstance = mixtape(tapeInstance, 4)
+    // testInstance.createStream() // silence output
+    let runs = new Set()
+    const testsDone = new Promise(resolve => testInstance.onFinish(resolve))
+    let t0 = Date.now()
+    let last = -1
+    Array(20).fill(1).forEach((el, index) => {
+      testInstance(`test ${index}`, t => {
+        const fn = () => {
+          runs.add(index)
+          t.ok(1)
+          t.comment(`${index} end ${Date.now() - t0}`)
+          last = index
+          t.end()
+        }
+        console.log(`${index} start  ${Date.now() - t0}`)
+        // t.comment(`${index} start`)
+        setTimeout(fn, index % 5 ? 10 : 100)
+      })
+    })
+    await testsDone
+    t.equal(last, 15, `the last index to finish was ${last}, expecting 15`)
+    t.equals(runs.size, 20, 'all tests ran')
+  } catch (e) {
+    t.fail(e.message)
+    t.end()
+  }
+})
+
+test('can run 10 wait-100ms test cases with concurrent limit==1', async t => {
+  t.plan(2)
+  try {
+    const numTests = 10
+    const concurrentLimit = 1
+    const waitms = 100
+    const tapeInstance = proxyquire('tape', {})
+    const testInstance = mixtape(tapeInstance, concurrentLimit)
+    // testInstance.createStream() // silence output
+    let runs = new Set()
+    const testsDone = new Promise(resolve => testInstance.onFinish(resolve))
+    const t0 = Date.now()
+    const finishTimes = Array(numTests).fill(0)
+    Array(numTests).fill(1).forEach((el, index) => {
+      testInstance(`test ${index}`, t => {
+        const fn = () => {
+          runs.add(index)
+          t.ok(1)
+          const finishTime = Date.now() - t0
+          finishTimes[index] = finishTime
+          t.comment(`${index} end ${finishTime}`)
+          t.end()
+        }
+        console.log(`${index} start  ${Date.now() - t0}`)
+        // t.comment(`${index} start  ${Date.now() - t0}`)
+        setTimeout(fn, waitms)
+      })
+    })
+    await testsDone
+    t.equals(runs.size, numTests, 'all tests ran')
+    let delaysOK = true
+    for (let i = 1; i < numTests; i++) {
+      if (finishTimes[i] - finishTimes[i - 1] - waitms < 0) {
+        delaysOK = false
+        t.assert(false,
+          `expected delay finishTimes[${i}]-finishTimes[${i - 1}]-waitms>=0, ` +
+          `actual ${finishTimes[i] - finishTimes[i - 1] - waitms}`)
+      }
+    }
+    t.assert(delaysOK, 'measured delays indicate concurrent constraint is working')
+  } catch (e) {
+    t.fail(e.message)
+    t.end()
+  }
+})


### PR DESCRIPTION
The last pull request had some problems.
I have added more testing in `test/concurrent.spec.js` and am certain it is working correctlty now.
Additionally, in 'README.md' I've added an psuedo-code example usage and a section discussing the tradeoffs when selecting a value for tte number of concurrent processes.

By the way, this pre-existing line in `README.md`

> In a lot of cases this is not an issue, but be wary when using this method. With reduced speed come unknown variables.

Maybe this is no longer applicable when a means to throttle the number of concurrent tests exists?  What are "unknown variables?".  Why would they "come with" reduced speed?  It is certainly a mysterious and discouraging thing to read.  Perhaps it could be removed?
